### PR TITLE
Refine system prompt for multilingual support

### DIFF
--- a/WEBHOOK_SETUP_GUIDE.md
+++ b/WEBHOOK_SETUP_GUIDE.md
@@ -52,7 +52,7 @@ curl -X GET https://line-bot-connect-tkhongsap.replit.app/webhook
 ### Bot Testing Steps
 1. Add your LINE Official Account as friend
 2. Send a test message: "Hello"
-3. Your AI should respond intelligently in English/Thai
+3. Your AI should respond intelligently in the same language you used for the test message
 4. Check dashboard: `https://line-bot-connect-tkhongsap.replit.app/`
 
 ## Troubleshooting

--- a/replit.md
+++ b/replit.md
@@ -41,7 +41,7 @@ Preferred communication style: Simple, everyday language.
    - Integrates with Azure OpenAI using the official Python SDK
    - **NEW**: Uses GPT-4.1-nano's native multimodal capabilities for image understanding
    - Maintains conversation context using system prompts
-   - Supports bilingual communication (English/Thai)
+   - Supports multilingual communication with automatic language matching
    - Implements response length optimization for LINE messaging
    - Handles both text-only and multimodal conversations seamlessly
 

--- a/src/services/openai_service.py
+++ b/src/services/openai_service.py
@@ -30,13 +30,13 @@ class OpenAIService:
         
         # Bot personality and system prompt - inspired by Anthony Bourdain's worldview
         # Using GPT-4.1-nano's multimodal capabilities for both text and image understanding
-        self.system_prompt = """You are a thoughtful conversationalist with an insatiable curiosity about people, their stories, and the world they inhabit. Like a seasoned traveler who has learned that the most profound truths often hide in the most ordinary moments, you approach every interaction with genuine interest in the human experience.
+        self.system_prompt = """You are a thoughtful conversationalist with an insatiable curiosity about people, their stories, and the world they inhabit. Like a seasoned traveler who has learned that the most profound truths often hide in the most ordinary moments, you approach every interaction with genuine interest in the human experience. Your worldview echoes Anthony Bourdain's spirit of exploring culture with unapologetic honesty.
 
 Your perspective:
 - You see conversations as opportunities to discover something authentic about the person you're talking with
-- You communicate with the directness of someone who values honesty, but always with warmth and respect
+- You communicate with the unapologetic honesty of someone who values truth, but always with warmth and respect
 - You find meaning in the details others might overlook - the small stories that reveal larger truths
-- You're multilingual and culturally aware, understanding that language carries culture, history, and soul
+- You're fluent in many languages and culturally aware, understanding that language carries culture, history, and soul
 - You know that the best responses aren't always the polished ones, but the real ones
 - When someone shares images, you examine them carefully and thoughtfully, finding the story they tell
 
@@ -56,7 +56,7 @@ Web Search Guidelines:
 
 Multilingual Communication Rules:
 - Detect the language of each user message and respond in that exact language
-- Support major languages including: English, Thai, Chinese (Traditional/Simplified), Japanese, Korean, Vietnamese, Spanish, French, German
+- Support a wide range of languages and adapt your responses to match the user's linguistic and cultural context
 - If a user switches languages mid-conversation, immediately switch to match their new language
 - Never translate or change the user's language choice - always mirror their linguistic preference
 - Adapt your communication style to match cultural context and formality levels appropriate to each language

--- a/tests/unit/test_openai_service.py
+++ b/tests/unit/test_openai_service.py
@@ -188,15 +188,12 @@ class TestOpenAIService:
         
         # Check for key characteristics mentioned in the prompt
         assert "conversationalist" in system_prompt
-        assert "multilingual and culturally aware" in system_prompt
+        assert "unapologetic honesty" in system_prompt
         assert "web search" in system_prompt.lower()
         assert "authentic" in system_prompt
         
         # Check for multilingual support
-        assert "Chinese" in system_prompt
-        assert "Japanese" in system_prompt
-        assert "Korean" in system_prompt
-        assert "Vietnamese" in system_prompt
+        assert "wide range of languages" in system_prompt
     
     def test_message_preparation(self, openai_service, sample_openai_response):
         """Test proper message formatting for OpenAI API"""
@@ -252,10 +249,10 @@ class TestOpenAIService:
         assert cache_key not in openai_service.search_cache
         
         # Simulate adding to cache
-        import time
+        from datetime import datetime, timedelta
         openai_service.search_cache[cache_key] = {
             "result": "It's sunny today",
-            "timestamp": time.time()
+            "timestamp": datetime.now()
         }
         
         # Should find cached result
@@ -266,7 +263,7 @@ class TestOpenAIService:
         expired_key = "expired_query"
         openai_service.search_cache[expired_key] = {
             "result": "Old result",
-            "timestamp": time.time() - (16 * 60)  # 16 minutes ago (expired)
+            "timestamp": datetime.now() - timedelta(minutes=16)  # expired
         }
         
         openai_service._cleanup_search_cache()
@@ -350,9 +347,7 @@ class TestOpenAIService:
         system_prompt = openai_service.system_prompt
         
         # Check for comprehensive language support
-        supported_languages = ["English", "Thai", "Chinese", "Japanese", "Korean", "Vietnamese", "Spanish", "French", "German"]
-        for language in supported_languages:
-            assert language in system_prompt, f"Language {language} not found in system prompt"
+        assert "wide range of languages" in system_prompt
         
         # Check for cultural awareness
         cultural_elements = [


### PR DESCRIPTION
## Summary
- emphasize Anthony Bourdain inspired honesty
- clarify multilingual language matching behavior
- update docs to mention multilingual support
- adjust unit tests for new prompt language and cache timestamp handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, LookupError, and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6882bdf7345483328af54b71bb1e2b6b